### PR TITLE
Feature: Add Vultr WAF resource, move resources to Terraform submodules.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,22 +4,38 @@ terraform {
       source = "vultr/vultr"
     }
   }
+  required_version = ">= 0.13"
 }
 
 provider "vultr" {
   api_key = var.vultr_api_key
 }
 
-resource "vultr_server" "irc_telegram_bridge" {
-  plan_id         = var.vultr_server_irc_telegram_bridge_plan_id
-  region_id       = var.vultr_server_irc_telegram_bridge_region_id
-  iso_id          = var.vultr_server_irc_telegram_bridge_iso_id
-  label           = var.vultr_server_irc_telegram_bridge_label
-  tag             = var.vultr_server_irc_telegram_bridge_tag
-  hostname        = var.vultr_server_irc_telegram_bridge_hostname
-  user_data       = var.vultr_server_irc_telegram_bridge_user_data
-  enable_ipv6     = var.vultr_server_irc_telegram_bridge_enable_ipv6
-  auto_backup     = var.vultr_server_irc_telegram_bridge_auto_backup
-  ddos_protection = var.vultr_server_irc_telegram_bridge_ddos_protection
-  notify_activate = var.vultr_server_irc_telegram_bridge_notify_activate
+module "vultr_server" {
+  source = "./modules/vultr_server"
+
+  irc_bridge_plan_id           = var.vultr_server_irc_bridge_plan_id
+  irc_bridge_region_id         = var.vultr_server_irc_bridge_region_id
+  irc_bridge_iso_id            = var.vultr_server_irc_bridge_iso_id
+  irc_bridge_label             = var.vultr_server_irc_bridge_label
+  irc_bridge_tag               = var.vultr_server_irc_bridge_tag
+  irc_bridge_hostname          = var.vultr_server_irc_bridge_hostname
+  irc_bridge_user_data         = var.vultr_server_irc_bridge_user_data
+  irc_bridge_enable_ipv6       = var.vultr_server_irc_bridge_enable_ipv6
+  irc_bridge_auto_backup       = var.vultr_server_irc_bridge_auto_backup
+  irc_bridge_ddos_protection   = var.vultr_server_irc_bridge_ddos_protection
+  irc_bridge_notify_activate   = var.vultr_server_irc_bridge_notify_activate
+  irc_bridge_firewall_group_id = module.vultr_firewall.irc_bridge_firewall_group_id
+}
+
+module "vultr_firewall" {
+  source = "./modules/vultr_firewall"
+
+  irc_bridge_firewall_group_description  = var.vultr_firewall_group_irc_bridge_firewall_group_description
+  irc_bridge_firewall_rule_ssh_port      = var.vultr_firewall_irc_bridge_firewall_rule_ssh_port
+  irc_bridge_firewall_rule_ssh_network   = var.vultr_firewall_irc_bridge_firewall_rule_ssh_network
+  irc_bridge_firewall_rule_irc_port      = var.vultr_firewall_irc_bridge_firewall_rule_irc_port
+  irc_bridge_firewall_rule_irc_network   = var.vultr_firewall_irc_bridge_firewall_rule_irc_network
+  irc_bridge_firewall_rule_https_port    = var.vultr_firewall_irc_bridge_firewall_rule_https_port
+  irc_bridge_firewall_rule_https_network = var.vultr_firewall_irc_bridge_firewall_rule_https_network
 }

--- a/modules/vultr_firewall/main.tf
+++ b/modules/vultr_firewall/main.tf
@@ -1,0 +1,24 @@
+resource "vultr_firewall_group" "irc_bridge_firewall" {
+  description = var.irc_bridge_firewall_group_description
+}
+
+resource "vultr_firewall_rule" "irc_bridge_firewall_rule_ssh" {
+  firewall_group_id = vultr_firewall_group.irc_bridge_firewall.id
+  protocol          = "tcp"
+  network           = var.irc_bridge_firewall_rule_ssh_network
+  from_port         = var.irc_bridge_firewall_rule_ssh_port
+}
+
+resource "vultr_firewall_rule" "irc_bridge_firewall_rule_irc" {
+  firewall_group_id = vultr_firewall_group.irc_bridge_firewall.id
+  protocol          = "tcp"
+  network           = var.irc_bridge_firewall_rule_irc_network
+  from_port         = var.irc_bridge_firewall_rule_irc_port
+}
+
+resource "vultr_firewall_rule" "irc_bridge_firewall_rule_https" {
+  firewall_group_id = vultr_firewall_group.irc_bridge_firewall.id
+  protocol          = "tcp"
+  network           = var.irc_bridge_firewall_rule_https_network
+  from_port         = var.irc_bridge_firewall_rule_https_port
+}

--- a/modules/vultr_firewall/outputs.tf
+++ b/modules/vultr_firewall/outputs.tf
@@ -1,0 +1,3 @@
+output "irc_bridge_firewall_group_id" {
+  value = vultr_firewall_group.irc_bridge_firewall.id
+}

--- a/modules/vultr_firewall/variables.tf
+++ b/modules/vultr_firewall/variables.tf
@@ -1,0 +1,30 @@
+################################################################################
+# vultr_firewall module variables
+################################################################################
+variable "irc_bridge_firewall_group_description" {
+  type = string
+}
+
+variable "irc_bridge_firewall_rule_ssh_port" {
+  type = string
+}
+
+variable "irc_bridge_firewall_rule_ssh_network" {
+  type = string
+}
+
+variable "irc_bridge_firewall_rule_irc_port" {
+  type = string
+}
+
+variable "irc_bridge_firewall_rule_irc_network" {
+  type = string
+}
+
+variable "irc_bridge_firewall_rule_https_port" {
+  type = string
+}
+
+variable "irc_bridge_firewall_rule_https_network" {
+  type = string
+}

--- a/modules/vultr_firewall/versions.tf
+++ b/modules/vultr_firewall/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    vultr = {
+      source = "vultr/vultr"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/vultr_server/main.tf
+++ b/modules/vultr_server/main.tf
@@ -1,0 +1,14 @@
+resource "vultr_server" "irc_bridge" {
+  plan_id           = var.irc_bridge_plan_id
+  region_id         = var.irc_bridge_region_id
+  iso_id            = var.irc_bridge_iso_id
+  label             = var.irc_bridge_label
+  tag               = var.irc_bridge_tag
+  hostname          = var.irc_bridge_hostname
+  user_data         = var.irc_bridge_user_data
+  enable_ipv6       = var.irc_bridge_enable_ipv6
+  auto_backup       = var.irc_bridge_auto_backup
+  ddos_protection   = var.irc_bridge_ddos_protection
+  notify_activate   = var.irc_bridge_notify_activate
+  firewall_group_id = var.irc_bridge_firewall_group_id
+}

--- a/modules/vultr_server/variables.tf
+++ b/modules/vultr_server/variables.tf
@@ -1,0 +1,50 @@
+################################################################################
+# vultr_server module variables
+################################################################################
+variable "irc_bridge_plan_id" {
+  type = string
+}
+
+variable "irc_bridge_region_id" {
+  type = string
+}
+
+variable "irc_bridge_iso_id" {
+  type = number
+}
+
+variable "irc_bridge_label" {
+  type = string
+}
+
+variable "irc_bridge_tag" {
+  type = string
+}
+
+variable "irc_bridge_hostname" {
+  type = string
+}
+
+variable "irc_bridge_user_data" {
+  type = string
+}
+
+variable "irc_bridge_enable_ipv6" {
+  type = bool
+}
+
+variable "irc_bridge_auto_backup" {
+  type = bool
+}
+
+variable "irc_bridge_ddos_protection" {
+  type = bool
+}
+
+variable "irc_bridge_notify_activate" {
+  type = bool
+}
+
+variable "irc_bridge_firewall_group_id" {
+  type = string
+}

--- a/modules/vultr_server/versions.tf
+++ b/modules/vultr_server/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    vultr = {
+      source = "vultr/vultr"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,48 +1,87 @@
+################################################################################
+# Project wide variables
+################################################################################
 variable "vultr_api_key" {
   type        = string
   description = "The API Key to authenticate with Vultr's API."
 }
 
-variable "vultr_server_irc_telegram_bridge_plan_id" {
+
+################################################################################
+# vultr_server irc_bridge variables
+################################################################################
+variable "vultr_server_irc_bridge_plan_id" {
   type = string
 }
 
-variable "vultr_server_irc_telegram_bridge_region_id" {
+variable "vultr_server_irc_bridge_region_id" {
   type = string
 }
 
-variable "vultr_server_irc_telegram_bridge_iso_id" {
+variable "vultr_server_irc_bridge_iso_id" {
   type = number
 }
 
-variable "vultr_server_irc_telegram_bridge_label" {
+variable "vultr_server_irc_bridge_label" {
   type = string
 }
 
-variable "vultr_server_irc_telegram_bridge_tag" {
+variable "vultr_server_irc_bridge_tag" {
   type = string
 }
 
-variable "vultr_server_irc_telegram_bridge_hostname" {
+variable "vultr_server_irc_bridge_hostname" {
   type = string
 }
 
-variable "vultr_server_irc_telegram_bridge_user_data" {
+variable "vultr_server_irc_bridge_user_data" {
   type = string
 }
 
-variable "vultr_server_irc_telegram_bridge_enable_ipv6" {
+variable "vultr_server_irc_bridge_enable_ipv6" {
   type = bool
 }
 
-variable "vultr_server_irc_telegram_bridge_auto_backup" {
+variable "vultr_server_irc_bridge_auto_backup" {
   type = bool
 }
 
-variable "vultr_server_irc_telegram_bridge_ddos_protection" {
+variable "vultr_server_irc_bridge_ddos_protection" {
   type = bool
 }
 
-variable "vultr_server_irc_telegram_bridge_notify_activate" {
+variable "vultr_server_irc_bridge_notify_activate" {
   type = bool
+}
+
+
+################################################################################
+# irc_bridge_firewall variables
+################################################################################
+variable "vultr_firewall_group_irc_bridge_firewall_group_description" {
+  type = string
+}
+
+variable "vultr_firewall_irc_bridge_firewall_rule_ssh_port" {
+  type = string
+}
+
+variable "vultr_firewall_irc_bridge_firewall_rule_ssh_network" {
+  type = string
+}
+
+variable "vultr_firewall_irc_bridge_firewall_rule_irc_port" {
+  type = string
+}
+
+variable "vultr_firewall_irc_bridge_firewall_rule_irc_network" {
+  type = string
+}
+
+variable "vultr_firewall_irc_bridge_firewall_rule_https_port" {
+  type = string
+}
+
+variable "vultr_firewall_irc_bridge_firewall_rule_https_network" {
+  type = string
 }


### PR DESCRIPTION
1. Why is this change neccesary?
Because we want to make use of Vultr's Web Application Firewall.
Because using Terraform submodules provides us with more organized, reusable code.

2. How does it address the issue?
By creating the WAF resource and implementing submodules.

3. What side effects does this change have?
None.