### PR TITLE
feature: Update Packer configuration to use Arch Linux images on Linode.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ create-variables: ## create variables files
 generate-docs: ## generate documentation for variables
 	@terraform-docs markdown terraform/ > README.md
 
-build: ## run the unit tests
+build: ## build the packer image
 	@packer build -var-file=variables/packer.json packer/
 
 init: ## generate documentation using pdoc

--- a/packer/main.pkr.hcl
+++ b/packer/main.pkr.hcl
@@ -1,37 +1,27 @@
-source "vultr" "irc_bridge" {
-  api_key              = var.vultr_api_key
-  os_id                = var.vultr_server_irc_bridge_os_id
-  plan_id              = var.vultr_server_irc_bridge_plan_id
-  region_id            = var.vultr_server_irc_bridge_region_id
-  snapshot_description = "Packer-test-with updates"
-  ssh_username         = "root"
-  state_timeout = "15m"
+source "linode" "community_gateway" {
+  linode_token      = var.linode_token
+  ssh_username      = var.ssh_username
+  image             = var.community_gateway_image
+  region            = var.community_gateway_region
+  instance_type     = var.community_gateway_instance_type
+  instance_label    = var.community_gateway_instance_label
+  instance_tags     = var.community_gateway_instance_tags
+  swap_size         = var.community_gateway_swap_size
+  image_label       = var.community_gateway_image_label
+  image_description = var.community_gateway_image_description
 }
 
 build {
+  name = "community_gateway"
+
   sources = [
-    "source.vultr.irc_bridge"
+    "source.linode.community_gateway"
   ]
-
-  provisioner "file"{
-    source = "variables/ansible.json"
-    destination = "/tmp/variables.json"
-  }
-
-  provisioner "file"{
-    source = "ansible/totp.yml"
-    destination = "/tmp/totp.yml"
-  }
 
   provisioner "shell" {
     inline = [
-      "sudo dnf install epel-release -y",
-      "sudo dnf makecache",
-      "sudo dnf install ansible -y"
+      "pacman -Syu --noconfirm",
+      "pacman -S ansible --noconfirm"
     ]
-  }
-
-  provisioner "ansible-local" {
-    playbook_file = "ansible/user.yml"
   }
 }

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -1,15 +1,61 @@
-variable "vultr_api_key" {
-  type    = string
+variable "linode_token" {
+  type        = string
+  sensitive   = true
+  description = "The client token to use to access your account."
 }
 
-variable "vultr_server_irc_bridge_os_id" {
-  type = string
+variable "ssh_username" {
+  type        = string
+  default     = "root"
+  description = "The SSH username used by the Packer communicator."
 }
 
-variable "vultr_server_irc_bridge_plan_id" {
-  type = string
+variable "community_gateway_image" {
+  type        = string
+  default     = "linode/arch"
+  description = "The image ID used to create the new image."
 }
 
-variable "vultr_server_irc_bridge_region_id" {
-  type = string
+variable "community_gateway_region" {
+  type        = string
+  default     = "us-central"
+  description = "The ID of the region to store the Linode image in."
+}
+
+variable "community_gateway_instance_type" {
+  type        = string
+  default     = "g6-nanode-1"
+  description = "The Linode instance type that defines the pricing, CPU, disk, and RAM specs of the instance."
+}
+
+variable "community_gateway_instance_label" {
+  type        = string
+  default     = "community_gateway"
+  description = "The name assigned to the Linode Instance."
+}
+
+variable "community_gateway_instance_tags" {
+  type        = list(string)
+  default     = [
+    "community_gateway", "archlinuxmx"
+  ]
+  description = "The tags to apply to the instance when it is created."
+}
+
+variable "community_gateway_swap_size" {
+  type        = string
+  default     = 512
+  description = "The disk size (MiB) allocated for swap space."
+}
+
+variable "community_gateway_image_label" {
+  type        = string
+  default     = "community_gateway"
+  description = "The name of the resulting image that will appear in your Linode account."
+}
+
+variable "community_gateway_image_description" {
+  type        = string
+  default     = "The Linode image for the community gateway project"
+  description = "The description of the resulting image that will appear in your account."
 }

--- a/variables/packer_sample.json
+++ b/variables/packer_sample.json
@@ -1,6 +1,3 @@
 {
-    "vultr_api_key": "",
-    "vultr_server_irc_bridge_plan_id": 201,
-    "vultr_server_irc_bridge_region_id": 2,
-    "vultr_server_irc_bridge_os_id": 362
+    "linode_token": ""
 }


### PR DESCRIPTION
1. Why is this change neccesary?
Because our current Packer template was created for Vultr and CentOS 8 but we're
no longer using Vultr nor CentOS 8 so we need to update our Packer image to use
Arch Linux on Linode instances.

2. How does it address the issue?
By updating the Packer template to use Arch Linux on Linode instances.

3. What side effects does this change have?
Closes #20