### PR TITLE
feature: Provision images with the Ansible playbook to create users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,19 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| linode\_firewall\_community\_gateway\_label | The label of the web application firewall | `string` | n/a | yes |
-| linode\_instance\_community\_gateway\_group | The display group of the Linode instance. | `string` | n/a | yes |
-| linode\_instance\_community\_gateway\_image | The OS image used to deploy the instance | `string` | n/a | yes |
-| linode\_instance\_community\_gateway\_label | The label to be displayed in Linode's servers | `string` | n/a | yes |
-| linode\_instance\_community\_gateway\_private\_ip | The private IP address for private networking | `bool` | n/a | yes |
-| linode\_instance\_community\_gateway\_region | The Linode region where the instance is deployed | `string` | n/a | yes |
-| linode\_instance\_community\_gateway\_root\_pass | The password for the root user | `string` | n/a | yes |
-| linode\_instance\_community\_gateway\_swap\_size | The swap disk size of the instance | `string` | n/a | yes |
-| linode\_instance\_community\_gateway\_type | The Linode type of the instance | `string` | n/a | yes |
-| linode\_sshkey\_community\_gateway\_key | The path to the SSH key that is attached to the instance | `string` | n/a | yes |
-| linode\_sshkey\_community\_gateway\_label | The label of the SSH key that is attached to the instance | `string` | n/a | yes |
-| linode\_token | The API Key to authenticate with Linode's API. | `string` | n/a | yes |
-| tags | A list of tags applied to resources in this repository. Tags are for organizational purposes only. | `list(string)` | n/a | yes |
+| linode\_firewall\_community\_gateway\_label | The label of the web application firewall | `string` | `"community_gateway"` | no |
+| linode\_instance\_community\_gateway\_group | The display group of the Linode instance. | `string` | `"community_gateway"` | no |
+| linode\_instance\_community\_gateway\_image | The OS image used to deploy the instance. | `string` | n/a | yes |
+| linode\_instance\_community\_gateway\_label | The name assigned to the Linode Instance. | `string` | `"community_gateway"` | no |
+| linode\_instance\_community\_gateway\_private\_ip | The private IP address for private networking. | `bool` | `false` | no |
+| linode\_instance\_community\_gateway\_root\_pass | The password for the root user. | `string` | n/a | yes |
+| linode\_instance\_community\_gateway\_swap\_size | The disk size (MiB) allocated for swap space. | `string` | `512` | no |
+| linode\_instance\_community\_gateway\_type | The Linode instance type that defines the pricing, CPU, disk, and RAM specs of the instance. | `string` | `"g6-nanode-1"` | no |
+| linode\_sshkey\_community\_gateway\_key | The path to the SSH key that is attached to the instance | `string` | `"~/.ssh/id_ed25519.pub"` | no |
+| linode\_sshkey\_community\_gateway\_label | The label of the SSH key that is attached to the instance | `string` | `"diyu"` | no |
+| linode\_token | The client token to use to access your account. | `string` | n/a | yes |
+| region | The location where the Linode is deployed. | `string` | `"us-central"` | no |
+| tags | The tags to apply to the resources when they are created. | `list(string)` | <pre>[<br>  "community_gateway",<br>  "archlinuxmx"<br>]</pre> | no |
 
 ## Outputs
 

--- a/ansible/user.yml
+++ b/ansible/user.yml
@@ -4,7 +4,7 @@
   gather_facts: False
 
   vars_files:
-  - /tmp/variables.json
+  - /tmp/ansible.json
 
   tasks:
   - name: Ensure the user is created

--- a/packer/main.pkr.hcl
+++ b/packer/main.pkr.hcl
@@ -24,4 +24,13 @@ build {
       "pacman -S ansible --noconfirm"
     ]
   }
+
+  provisioner "file"{
+    sources     = ["variables/ansible.json", "ansible/totp.yml"]
+    destination = "/tmp/"
+  }
+
+  provisioner "ansible-local" {
+    playbook_file   = "./ansible/user.yml"
+  }
 }

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -30,8 +30,8 @@ variable "community_gateway_instance_type" {
 
 variable "community_gateway_instance_label" {
   type        = string
-  default     = "community_gateway"
-  description = "The name assigned to the Linode Instance."
+  default     = "community_gateway_builder"
+  description = "The name assigned to the Linode Instance that builds the image."
 }
 
 variable "community_gateway_instance_tags" {


### PR DESCRIPTION
1. Why is this change neccesary?
Because we need to create a user when building the Packer image.

2. How does it address the issue?
By adding an Ansible playbook that creates and configures a user when building
the image.

3. What side effects does this change have?
Closes #24